### PR TITLE
fix: Add compute.regionInstanceGroupManagers.update to vm_mig_detach_policy

### DIFF
--- a/modules/response/templates/gcp_roles/vm_mig_detach_policy.json
+++ b/modules/response/templates/gcp_roles/vm_mig_detach_policy.json
@@ -2,6 +2,7 @@
   "includedPermissions": [
      "compute.instances.get",
      "compute.instanceGroupManagers.update",
+     "compute.regionInstanceGroupManagers.update",
      "logging.logEntries.create"
     ],
   "name": "projects/${projectId}/roles/vm_mig_detach_role",


### PR DESCRIPTION
## Summary
- Adds `compute.regionInstanceGroupManagers.update` to the `vm_mig_detach_role` IAM role
- The `StreamSecurityGcpVmMIGDetach` runbook calls both `instanceGroupManagers.abandonInstances` (zonal) and `regionInstanceGroupManagers.abandonInstances` (regional); the regional path requires this permission
- Without it, abandoning a VM from a regional MIG fails with permission denied

## Related
Mirrors fix in lightlytics/lightlytics#19883

🤖 Generated with [Claude Code](https://claude.com/claude-code)