### PR TITLE
revert: Remove invalid compute.regionInstanceGroupManagers.update permission

### DIFF
--- a/modules/response/templates/gcp_roles/vm_mig_detach_policy.json
+++ b/modules/response/templates/gcp_roles/vm_mig_detach_policy.json
@@ -2,7 +2,6 @@
   "includedPermissions": [
      "compute.instances.get",
      "compute.instanceGroupManagers.update",
-     "compute.regionInstanceGroupManagers.update",
      "logging.logEntries.create"
     ],
   "name": "projects/${projectId}/roles/vm_mig_detach_role",


### PR DESCRIPTION
## Summary
Reverts the change from PR #35.

`compute.regionInstanceGroupManagers.update` is **not a valid GCP IAM permission** — GCP doesn't expose a separate `regionInstanceGroupManagers` permission namespace. The `compute.instanceGroupManagers.update` permission already covers both zonal and regional MIG operations (confirmed by attempting to create a custom role with the invalid permission: `INVALID_ARGUMENT: Permission compute.regionInstanceGroupManagers.update is not valid`).

The original role was correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)