### PR TITLE
DEV-19337 fix GCP VM and Cloud Run isolation runbooks

### DIFF
--- a/modules/response/templates/runbook_config.yaml
+++ b/modules/response/templates/runbook_config.yaml
@@ -14,7 +14,7 @@ Remediations:
     type: String
     resource_name: true
 - name: StreamSecurityGcpIsolatedVMFromAllNetwork
-  description: Creates deny-all ingress and egress firewall rules and replaces all VM network tags with the isolation tag. Pre-existing tags and their firewall targeting are removed.
+  description: Isolates a VM by creating priority-0 deny-all firewall rules across all connected VPCs and appending the isolation tag. Existing tags are preserved.
   disabled_reason: Action is not applicable because the isolation firewall rules are already attached to the VM instance.
   display_name: Isolate VM Instance from All Networks
   remediation_type: runbook
@@ -212,8 +212,8 @@ Remediations:
     type: String
     resource_name: true
 - name: StreamSecurityGcpIsolateRunFunctionByDenyEgressFirewallRule
-  description: Blocks all outbound traffic from a Cloud Run service using Direct VPC Egress by creating a deny-all egress firewall rule in its VPC and tagging the service's network interface to enforce the rule.
-  disabled_reason: Action is not applicable because the function is already isolated by a deny-egress firewall rule.
+  description: Blocks outbound VPC traffic from a Cloud Run service by creating high-priority deny-all egress firewall rules across all configured Direct VPC Egress network interfaces and appending an isolation tag to each interface. Existing tags are preserved.
+  disabled_reason: Action is not applicable because the Cloud Run service has no Direct VPC Egress network interfaces configured.
   display_name: Isolate Cloud Function by Deny Egress Firewall Rule
   remediation_type: runbook
   cloud_provider: gcp

--- a/modules/response/templates/runbook_config.yaml
+++ b/modules/response/templates/runbook_config.yaml
@@ -212,8 +212,8 @@ Remediations:
     type: String
     resource_name: true
 - name: StreamSecurityGcpIsolateRunFunctionByDenyEgressFirewallRule
-  description: Blocks outbound VPC traffic from a Cloud Run service by creating high-priority deny-all egress firewall rules across all configured Direct VPC Egress network interfaces and appending an isolation tag to each interface. Existing tags are preserved.
-  disabled_reason: Action is not applicable because the Cloud Run service has no Direct VPC Egress network interfaces configured.
+  description: Blocks all outbound traffic from a Cloud Run service using Direct VPC Egress by creating a deny-all egress firewall rule in its VPC and tagging the service's network interface to enforce the rule.
+  disabled_reason: Action is not applicable because the function is already isolated by a deny-egress firewall rule.
   display_name: Isolate Cloud Function by Deny Egress Firewall Rule
   remediation_type: runbook
   cloud_provider: gcp

--- a/modules/response/templates/runbooks/StreamSecurityGcpIsolateRunFunctionByDenyEgressFirewallRule.yaml
+++ b/modules/response/templates/runbooks/StreamSecurityGcpIsolateRunFunctionByDenyEgressFirewallRule.yaml
@@ -28,6 +28,7 @@ main:
           - location: ${parts[3]}
           - function_name: ${parts[5]}
 
+
     # Step 3: Get function details
     - getFunction:
         try:
@@ -43,6 +44,8 @@ main:
                 status_code: "error"
                 message: ${e.body.error.message}
 
+
+
     # Step 4: Check if function is connected to a VPC
     - checkVpcConnection:
         try:
@@ -57,73 +60,54 @@ main:
                 status_code: "error"
                 message: ${ er }
 
-    # Step 5: Check if VPC network interfaces are configured
+     # Step 5a: Check if VPC exists before accessing networkInterfaces
     - checkVpcInterfaces:
         switch:
           - condition: ${not("vpcAccess" in function.template) or not("networkInterfaces" in function.template.vpcAccess) or len(function.template.vpcAccess.networkInterfaces) == 0}
             return:
               status_code: "ok"
               message: ${"Service is not connected to a VPC. No action taken."}
-        next: initLoop
+        next: extractVpcName
 
-    # Step 6: Initialise the updated interfaces list before the loop
-    - initLoop:
+    # Step 5b: Extract network name from the full resource URL
+    - extractVpcName:
         assign:
-          - updated_interfaces: []
+          - network_full_url: ${function.template.vpcAccess.networkInterfaces[0].network}
+          - network_parts: ${text.split(network_full_url, "/")}
+          - vpc_name: ${network_parts[len(network_parts) - 1]}
 
-    # Step 7: For every VPC the function is connected to:
-    #   a) Create a priority-0 deny-all egress firewall rule targeting "isolatedfunctionegressstream".
-    #      The same rule is reused if multiple NICs share a VPC (409 ignored).
-    #   b) Append "isolatedfunctionegressstream" to the NIC's existing tags.
-    #      The if() guard prevents duplicates if the runbook runs more than once.
-    #      Existing tags are preserved so other firewall rules on the NIC remain effective.
-    - createFirewallRulesPerVPC:
-        for:
-          value: nic
-          in: ${function.template.vpcAccess.networkInterfaces}
-          steps:
-            - extractNicVpc:
-                assign:
-                  - network_full_url: ${nic.network}
-                  - network_parts: ${text.split(network_full_url, "/")}
-                  - vpc_name: ${network_parts[len(network_parts) - 1]}
-                  - network_url: ${"https://www.googleapis.com/compute/v1/projects/" + project_id + "/global/networks/" + vpc_name}
-                  - firewall_egress: ${"isolated-function-egress-stream-" + vpc_name}
-            - createEgress:
-                try:
-                    call: googleapis.compute.v1.firewalls.insert
-                    args:
-                        project: ${project_id}
-                        body:
-                            name: ${firewall_egress}
-                            network: ${network_url}
-                            direction: "EGRESS"
-                            priority: 0
-                            denied:
-                            - IPProtocol: "all"
-                            destinationRanges:
-                            - "0.0.0.0/0"
-                            targetTags: ["isolatedfunctionegressstream"]
-                except:
-                  as: e
-                  switch:
-                    - condition: ${e.body.error.code != 409}
-                      raise:
-                        status_code: "error"
-                        message: ${e.body.error.message}
-            - buildUpdatedNic:
-                assign:
-                  - existing_nic_tags: ${default(map.get(nic, "tags"), [])}
-                  - new_nic_tags: ${if("isolatedfunctionegressstream" in existing_nic_tags, existing_nic_tags, list.concat(existing_nic_tags, ["isolatedfunctionegressstream"]))}
-                  - updated_nic:
-                      network: ${nic.network}
-                      subnetwork: ${nic.subnetwork}
-                      tags: ${new_nic_tags}
-                  - updated_interfaces: ${list.concat(updated_interfaces, [updated_nic])}
+    # Step 6: Define firewall And Network
+    - defineFirewallAndNetwork:
+        assign:
+            - firewall_egress: ${"isolated-function-egress-stream-" + vpc_name}
+            - network_url: ${"https://www.googleapis.com/compute/v1/projects/" + project_id + "/global/networks/" + vpc_name}
 
-    # Step 8: Patch all network interfaces in a single API call with their updated tags.
-    # Adding "isolatedfunctionegressstream" to each NIC activates the deny-all egress
-    # firewall rules created in Step 7 for that specific service.
+    # Step 7: Create new deny-all EGRESS firewall rule
+    - createEgress:
+        try:
+            call: googleapis.compute.v1.firewalls.insert
+            args:
+                project: ${project_id}
+                body:
+                    name: ${firewall_egress}
+                    network: ${network_url}
+                    direction: "EGRESS"
+                    priority: 100
+                    denied:
+                    - IPProtocol: "all"
+                    destinationRanges:
+                    - "0.0.0.0/0"
+                    targetTags: ["isolatedfunctionegressstream"]
+        except:
+          as: e
+          switch:
+            - condition: ${e.body.error.code != 409}
+              raise:
+                status_code: "error"
+                message: ${e.body.error.message}
+
+
+    # Step 8: Add the target network tag to the function
     - updateFunctionTags:
         try:
             call: googleapis.run.v2.projects.locations.services.patch
@@ -133,7 +117,11 @@ main:
                 body:
                     template:
                         vpcAccess:
-                            networkInterfaces: ${updated_interfaces}
+                            networkInterfaces:
+                                - network: ${function.template.vpcAccess.networkInterfaces[0].network}
+                                  subnetwork: ${function.template.vpcAccess.networkInterfaces[0].subnetwork}
+                                  tags: ["isolatedfunctionegressstream"]
+
         except:
             as: e
             switch:
@@ -142,8 +130,9 @@ main:
                     status_code: "error"
                     message: ${e.body.error.message}
 
+
     # Final step: return success
     - done:
         return:
           status_code: "success"
-          message: ${"Function " + function_name + " is now isolated via deny-all egress firewall rules on all connected VPCs."}
+          message: ${"Function " + function_name + " is now isolated via firewall rule on VPC " }

--- a/modules/response/templates/runbooks/StreamSecurityGcpIsolateRunFunctionByDenyEgressFirewallRule.yaml
+++ b/modules/response/templates/runbooks/StreamSecurityGcpIsolateRunFunctionByDenyEgressFirewallRule.yaml
@@ -28,7 +28,6 @@ main:
           - location: ${parts[3]}
           - function_name: ${parts[5]}
 
-
     # Step 3: Get function details
     - getFunction:
         try:
@@ -44,8 +43,6 @@ main:
                 status_code: "error"
                 message: ${e.body.error.message}
 
-
-
     # Step 4: Check if function is connected to a VPC
     - checkVpcConnection:
         try:
@@ -60,54 +57,73 @@ main:
                 status_code: "error"
                 message: ${ er }
 
-     # Step 5a: Check if VPC exists before accessing networkInterfaces
+    # Step 5: Check if VPC network interfaces are configured
     - checkVpcInterfaces:
         switch:
           - condition: ${not("vpcAccess" in function.template) or not("networkInterfaces" in function.template.vpcAccess) or len(function.template.vpcAccess.networkInterfaces) == 0}
             return:
               status_code: "ok"
               message: ${"Service is not connected to a VPC. No action taken."}
-        next: extractVpcName
+        next: initLoop
 
-    # Step 5b: Extract network name from the full resource URL
-    - extractVpcName:
+    # Step 6: Initialise the updated interfaces list before the loop
+    - initLoop:
         assign:
-          - network_full_url: ${function.template.vpcAccess.networkInterfaces[0].network}
-          - network_parts: ${text.split(network_full_url, "/")}
-          - vpc_name: ${network_parts[len(network_parts) - 1]}
+          - updated_interfaces: []
 
-    # Step 6: Define firewall And Network
-    - defineFirewallAndNetwork:
-        assign:
-            - firewall_egress: ${"isolated-function-egress-stream-" + vpc_name}
-            - network_url: ${"https://www.googleapis.com/compute/v1/projects/" + project_id + "/global/networks/" + vpc_name}
+    # Step 7: For every VPC the function is connected to:
+    #   a) Create a priority-0 deny-all egress firewall rule targeting "isolatedfunctionegressstream".
+    #      The same rule is reused if multiple NICs share a VPC (409 ignored).
+    #   b) Append "isolatedfunctionegressstream" to the NIC's existing tags.
+    #      The if() guard prevents duplicates if the runbook runs more than once.
+    #      Existing tags are preserved so other firewall rules on the NIC remain effective.
+    - createFirewallRulesPerVPC:
+        for:
+          value: nic
+          in: ${function.template.vpcAccess.networkInterfaces}
+          steps:
+            - extractNicVpc:
+                assign:
+                  - network_full_url: ${nic.network}
+                  - network_parts: ${text.split(network_full_url, "/")}
+                  - vpc_name: ${network_parts[len(network_parts) - 1]}
+                  - network_url: ${"https://www.googleapis.com/compute/v1/projects/" + project_id + "/global/networks/" + vpc_name}
+                  - firewall_egress: ${"isolated-function-egress-stream-" + vpc_name}
+            - createEgress:
+                try:
+                    call: googleapis.compute.v1.firewalls.insert
+                    args:
+                        project: ${project_id}
+                        body:
+                            name: ${firewall_egress}
+                            network: ${network_url}
+                            direction: "EGRESS"
+                            priority: 0
+                            denied:
+                            - IPProtocol: "all"
+                            destinationRanges:
+                            - "0.0.0.0/0"
+                            targetTags: ["isolatedfunctionegressstream"]
+                except:
+                  as: e
+                  switch:
+                    - condition: ${e.body.error.code != 409}
+                      raise:
+                        status_code: "error"
+                        message: ${e.body.error.message}
+            - buildUpdatedNic:
+                assign:
+                  - existing_nic_tags: ${default(map.get(nic, "tags"), [])}
+                  - new_nic_tags: ${if("isolatedfunctionegressstream" in existing_nic_tags, existing_nic_tags, list.concat(existing_nic_tags, ["isolatedfunctionegressstream"]))}
+                  - updated_nic:
+                      network: ${nic.network}
+                      subnetwork: ${nic.subnetwork}
+                      tags: ${new_nic_tags}
+                  - updated_interfaces: ${list.concat(updated_interfaces, [updated_nic])}
 
-    # Step 7: Create new deny-all EGRESS firewall rule
-    - createEgress:
-        try:
-            call: googleapis.compute.v1.firewalls.insert
-            args:
-                project: ${project_id}
-                body:
-                    name: ${firewall_egress}
-                    network: ${network_url}
-                    direction: "EGRESS"
-                    priority: 100
-                    denied:
-                    - IPProtocol: "all"
-                    destinationRanges:
-                    - "0.0.0.0/0"
-                    targetTags: ["isolatedfunctionegressstream"]
-        except:
-          as: e
-          switch:
-            - condition: ${e.body.error.code != 409}
-              raise:
-                status_code: "error"
-                message: ${e.body.error.message}
-
-
-    # Step 8: Add the target network tag to the function
+    # Step 8: Patch all network interfaces in a single API call with their updated tags.
+    # Adding "isolatedfunctionegressstream" to each NIC activates the deny-all egress
+    # firewall rules created in Step 7 for that specific service.
     - updateFunctionTags:
         try:
             call: googleapis.run.v2.projects.locations.services.patch
@@ -117,11 +133,7 @@ main:
                 body:
                     template:
                         vpcAccess:
-                            networkInterfaces:
-                                - network: ${function.template.vpcAccess.networkInterfaces[0].network}
-                                  subnetwork: ${function.template.vpcAccess.networkInterfaces[0].subnetwork}
-                                  tags: ["isolatedfunctionegressstream"]
-
+                            networkInterfaces: ${updated_interfaces}
         except:
             as: e
             switch:
@@ -130,9 +142,8 @@ main:
                     status_code: "error"
                     message: ${e.body.error.message}
 
-
     # Final step: return success
     - done:
         return:
           status_code: "success"
-          message: ${"Function " + function_name + " is now isolated via firewall rule on VPC " }
+          message: ${"Function " + function_name + " is now isolated via deny-all egress firewall rules on all connected VPCs."}

--- a/modules/response/templates/runbooks/StreamSecurityGcpIsolatedVMFromAllNetwork.yaml
+++ b/modules/response/templates/runbooks/StreamSecurityGcpIsolatedVMFromAllNetwork.yaml
@@ -29,7 +29,7 @@ main:
           - zone: ${parts[3]}
           - instance_name: ${parts[5]}
 
-    # Step 2: Get instance details (to extract network and fingerprint)
+    # Step 2: Get instance details to enumerate network interfaces
     - getInstance:
         call: googleapis.compute.v1.instances.get
         args:
@@ -38,71 +38,84 @@ main:
           instance: ${instance_name}
         result: instance
 
-    # Step 3: Extract network and VPC name
-    - extractNetwork:
+    # Step 3: Create deny-all ingress and egress firewall rules for every VPC the VM belongs to.
+    # Rules are keyed by vpc_name so the same rule is reused if multiple NICs share a VPC (409 ignored).
+    - createFirewallRulesPerVPC:
+        for:
+          value: nic
+          in: ${instance.networkInterfaces}
+          steps:
+            - extractNicNetwork:
+                assign:
+                  - network_url: ${nic.network}
+                  - network_parts: ${text.split(network_url, "/")}
+                  - vpc_name: ${network_parts[len(network_parts) - 1]}
+                  - firewall_ingress: ${"isolated-fw-stream-ingress-" + vpc_name}
+                  - firewall_egress: ${"isolated-fw-stream-egress-" + vpc_name}
+            - createIngress:
+                try:
+                    call: googleapis.compute.v1.firewalls.insert
+                    args:
+                        project: ${project_id}
+                        body:
+                            name: ${firewall_ingress}
+                            network: ${network_url}
+                            direction: "INGRESS"
+                            priority: 0
+                            denied:
+                            - IPProtocol: "all"
+                            sourceRanges:
+                            - "0.0.0.0/0"
+                            targetTags: ["isolatedstream"]
+                except:
+                  as: e
+                  switch:
+                    - condition: ${e.body.error.code != 409}
+                      raise:
+                        status_code: "error"
+                        message: ${e.body.error.message}
+            - createEgress:
+                try:
+                    call: googleapis.compute.v1.firewalls.insert
+                    args:
+                        project: ${project_id}
+                        body:
+                            name: ${firewall_egress}
+                            network: ${network_url}
+                            direction: "EGRESS"
+                            priority: 0
+                            denied:
+                            - IPProtocol: "all"
+                            destinationRanges:
+                            - "0.0.0.0/0"
+                            targetTags: ["isolatedstream"]
+                except:
+                  as: e
+                  switch:
+                    - condition: ${e.body.error.code != 409}
+                      raise:
+                        status_code: "error"
+                        message: ${e.body.error.message}
+
+    # Step 4: Re-fetch the instance to get a fresh tag fingerprint.
+    # Firewall insertions above can take time; re-fetching avoids a 412 Precondition Failed
+    # if another process modified the VM's tags while we were creating firewall rules.
+    - getInstanceFresh:
+        call: googleapis.compute.v1.instances.get
+        args:
+          project: ${project_id}
+          zone: ${zone}
+          instance: ${instance_name}
+        result: instance_fresh
+
+    # Step 5: Append "isolatedstream" to existing tags rather than replacing them.
+    # Preserves load-balancer rules, health checks, and other GCP features that rely on network tags.
+    # The if() guard prevents a duplicate tag if the runbook is executed more than once.
+    - prepareNewTags:
         assign:
-          - network_url: ${instance.networkInterfaces[0].network}
-          - network_parts: ${text.split(network_url, "/")}
-          - vpc_name: ${network_parts[len(network_parts) - 1]}
+          - existing_tags: ${default(map.get(instance_fresh.tags, "items"), [])}
+          - new_tags: ${if("isolatedstream" in existing_tags, existing_tags, list.concat(existing_tags, ["isolatedstream"]))}
 
-    # Step 4: Define firewall names based on VPC name
-    - defineFirewallNames:
-        assign:
-          - firewall_ingress: ${"isolated-fw-stream" + "-ingress-" + vpc_name }
-          - firewall_egress: ${"isolated-fw-stream" + "-egress-" + vpc_name }
-
-
-    # Step 7: Create new deny-all INGRESS firewall rule
-    - createIngress:
-        try:
-            call: googleapis.compute.v1.firewalls.insert
-            args:
-                project: ${project_id}
-                body:
-                    name: ${firewall_ingress}
-                    network: ${network_url}
-                    direction: "INGRESS"
-                    priority: 100
-                    denied:
-                    - IPProtocol: "all"
-                    sourceRanges:
-                    - "0.0.0.0/0"
-                    targetTags: ["isolatedstream"]
-        except:
-          as: e
-          switch:
-            - condition: ${e.body.error.code != 409}
-              raise:
-                status_code: "error"
-                message: ${e.body.error.message}
-
-    # Step 8: Create new deny-all EGRESS firewall rule
-    - createEgress:
-        try:
-            call: googleapis.compute.v1.firewalls.insert
-            args:
-                project: ${project_id}
-                body:
-                    name: ${firewall_egress}
-                    network: ${network_url}
-                    direction: "EGRESS"
-                    priority: 100
-                    denied:
-                    - IPProtocol: "all"
-                    destinationRanges:
-                    - "0.0.0.0/0"
-                    targetTags: ["isolatedstream"]
-        except:
-          as: e
-          switch:
-            - condition: ${e.body.error.code != 409}
-              raise:
-                status_code: "error"
-                message: ${e.body.error.message}
-
-
-
-    # Step 9: Replace VM tags with only "isolatedstream"
     - setIsolatedTag:
         call: googleapis.compute.v1.instances.setTags
         args:
@@ -110,8 +123,8 @@ main:
           zone: ${zone}
           instance: ${instance_name}
           body:
-            items: ["isolatedstream"]
-            fingerprint: ${instance.tags.fingerprint}
+            items: ${new_tags}
+            fingerprint: ${instance_fresh.tags.fingerprint}
 
     # Final Step
     - done:


### PR DESCRIPTION
## Summary

Syncs the fixed isolation runbooks from the lightlytics monorepo ([PR #20196](https://github.com/lightlytics/lightlytics/pull/20196)).

- **Priority 0**: Firewall rules changed from priority 100 to 0 — priority 0 is the maximum in GCP and cannot be overridden by any other rule
- **Multi-NIC coverage**: VM runbook now loops over all `networkInterfaces` (was only `networkInterfaces[0]`); Cloud Run runbook loops over all `vpcAccess.networkInterfaces` — one firewall rule per unique VPC (409 silently ignored)
- **Tag safety**: Both runbooks now append the isolation tag instead of replacing all existing tags, preserving load-balancer, health-check, and GKE targeting
- **Stale fingerprint fix**: VM runbook re-fetches the instance immediately before `setTags` to avoid 412 Precondition Failed
- **Descriptions**: Updated `runbook_config.yaml` descriptions for both runbooks

## Test plan

- [ ] `terraform plan` with updated templates — verify no unexpected resource changes beyond workflow content updates
- [ ] Deploy to a test project; run VM isolation runbook and confirm priority-0 rules are created in each VPC
- [ ] Run Cloud Run isolation runbook and confirm egress deny rule with priority 0 in each configured VPC
- [ ] Re-run both runbooks — verify idempotency (no duplicate tags, 409 silently ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)