### PR TITLE
DEV-19182 Add GCP Revoke Service Account Keys runbook and role

### DIFF
--- a/modules/response/templates/gcp_roles/gcp_revoke_service_account_keys.json
+++ b/modules/response/templates/gcp_roles/gcp_revoke_service_account_keys.json
@@ -5,6 +5,6 @@
     "iam.serviceAccounts.get",
     "logging.logEntries.create"
   ],
-  "name": "projects/${projectId}/roles/customRevokeServiceAccountKeysRole",
+  "name": "projects/${projectId}/roles/customDeleteServiceAccountKeysRole",
   "title": "GCP Stream Delete Service Account Keys Role"
 }

--- a/modules/response/templates/gcp_roles/gcp_revoke_service_account_keys.json
+++ b/modules/response/templates/gcp_roles/gcp_revoke_service_account_keys.json
@@ -6,5 +6,5 @@
     "logging.logEntries.create"
   ],
   "name": "projects/${projectId}/roles/customRevokeServiceAccountKeysRole",
-  "title": "GCP Stream Revoke Service Account Keys Role"
+  "title": "GCP Stream Delete Service Account Keys Role"
 }

--- a/modules/response/templates/runbook_config.yaml
+++ b/modules/response/templates/runbook_config.yaml
@@ -304,7 +304,7 @@ Remediations:
     resource_name: true
 
 - name: StreamSecurityGcpRotateServiceAccountKeys
-  description: Immediately deletes all USER_MANAGED keys from a service account, revoking any signed URLs and persistent credentials issued with those keys. Does not create replacement keys
+  description: Immediately deletes all USER_MANAGED keys from a service account. Does not create replacement keys.
   disabled_reason: Action is not applicable because the service account has no user-managed keys.
   display_name: Revoke Service Account Keys
   remediation_type: runbook

--- a/modules/response/templates/runbook_config.yaml
+++ b/modules/response/templates/runbook_config.yaml
@@ -302,3 +302,18 @@ Remediations:
   - name: ServiceAccountId
     type: String
     resource_name: true
+    
+- name: StreamSecurityGcpRevokeServiceAccountKeys
+  description: Immediately deletes all USER_MANAGED keys from a service account, revoking any signed URLs and persistent credentials issued with those keys. Does not create replacement keys
+  disabled_reason: Action is not applicable because the service account has no user-managed keys.
+  display_name: Revoke Service Account Keys
+  remediation_type: runbook
+  cloud_provider: gcp
+  resource_type: gcp_service_account
+  runbook_owner: StreamSecurity
+  role_name: GCP Stream Revoke Service Account Keys Role
+  role_file: gcp_revoke_service_account_keys.json
+  Parameters:
+  - name: ServiceAccountId
+    type: String
+    resource_name: true

--- a/modules/response/templates/runbook_config.yaml
+++ b/modules/response/templates/runbook_config.yaml
@@ -306,12 +306,12 @@ Remediations:
 - name: StreamSecurityGcpRotateServiceAccountKeys
   description: Immediately deletes all USER_MANAGED keys from a service account. Does not create replacement keys.
   disabled_reason: Action is not applicable because the service account has no user-managed keys.
-  display_name: Revoke Service Account Keys
+  display_name: Delete Service Account Keys
   remediation_type: runbook
   cloud_provider: gcp
   resource_type: gcp_service_account
   runbook_owner: StreamSecurity
-  role_name: GCP Stream Revoke Service Account Keys Role
+  role_name: GCP Stream Delete Service Account Keys Role
   role_file: gcp_revoke_service_account_keys.json
   Parameters:
   - name: ServiceAccountId

--- a/modules/response/templates/runbook_config.yaml
+++ b/modules/response/templates/runbook_config.yaml
@@ -303,7 +303,7 @@ Remediations:
     type: String
     resource_name: true
     
-- name: StreamSecurityGcpRevokeServiceAccountKeys
+- name: StreamSecurityGcpRotateServiceAccountKeys
   description: Immediately deletes all USER_MANAGED keys from a service account, revoking any signed URLs and persistent credentials issued with those keys. Does not create replacement keys
   disabled_reason: Action is not applicable because the service account has no user-managed keys.
   display_name: Revoke Service Account Keys

--- a/modules/response/templates/runbook_config.yaml
+++ b/modules/response/templates/runbook_config.yaml
@@ -302,7 +302,7 @@ Remediations:
   - name: ServiceAccountId
     type: String
     resource_name: true
-    
+
 - name: StreamSecurityGcpRotateServiceAccountKeys
   description: Immediately deletes all USER_MANAGED keys from a service account, revoking any signed URLs and persistent credentials issued with those keys. Does not create replacement keys
   disabled_reason: Action is not applicable because the service account has no user-managed keys.

--- a/modules/response/templates/runbooks/StreamSecurityGcpRevokeServiceAccountKeys.yaml
+++ b/modules/response/templates/runbooks/StreamSecurityGcpRevokeServiceAccountKeys.yaml
@@ -1,0 +1,97 @@
+main:
+  params: [input]
+  steps:
+    - parseInputs:
+        assign:
+          - sa_input: ${input.ServiceAccountId}
+
+    - logInput:
+        call: sys.log
+        args:
+          text: ${"Runbook started. ServiceAccountId='" + sa_input + "'"}
+          severity: INFO
+
+    - normalize:
+        switch:
+          - condition: ${text.match_regex(sa_input, "^projects/[^/]+/serviceAccounts/.+")}
+            assign:
+              - sa_name: ${sa_input}
+          - condition: ${text.find_all(sa_input, "@") != []}
+            assign:
+              - parts: ${text.split(sa_input, "@")}
+              - domain_parts: ${text.split(parts[1], ".")}
+              - project_id: ${domain_parts[0]}
+              - sa_name: ${"projects/" + project_id + "/serviceAccounts/" + sa_input}
+          - condition: true
+            raise:
+              status_code: "error"
+              message: ${"Invalid ServiceAccountId. Expected 'projects/<p>/serviceAccounts/<email>' or a bare SA email; got; " + sa_input}
+
+    # List only user-managed keys — system-managed keys are rotated by GCP
+    # automatically and must not be deleted. The keyTypes filter does the
+    # pre-filtering server-side so we don't have to branch on key.keyType
+    # for every element.
+    - listKeys:
+        try:
+          call: http.get
+          args:
+            url: ${"https://iam.googleapis.com/v1/" + sa_name + "/keys?keyTypes=USER_MANAGED"}
+            auth:
+              type: OAuth2
+          result: keysResp
+        except:
+          as: er
+          raise:
+            status_code: "error"
+            message: ${"Failed to list keys; " + default(er.body.error.message, json.encode_to_string(er))}
+    - checkListStatus:
+        switch:
+          - condition: ${keysResp.code >= 400}
+            raise:
+              status_code: "error"
+              message: ${"Failed to list keys; HTTP " + string(keysResp.code)}
+
+    - init:
+        assign:
+          - keys: ${default(keysResp.body.keys, [])}
+          - deleted: []
+
+    - checkEmpty:
+        switch:
+          - condition: ${len(keys) == 0}
+            return:
+              status_code: "success"
+              message: ${"No user-managed keys on " + sa_name + "; nothing to rotate."}
+
+    - deleteKeys:
+        for:
+          value: key
+          in: ${keys}
+          steps:
+            - doDelete:
+                try:
+                  call: http.delete
+                  args:
+                    url: ${"https://iam.googleapis.com/v1/" + key.name}
+                    auth:
+                      type: OAuth2
+                  result: deleteResp
+                except:
+                  as: er
+                  raise:
+                    status_code: "error"
+                    message: ${"Failed to delete key " + key.name + "; " + default(er.body.error.message, json.encode_to_string(er))}
+            - checkDeleteStatus:
+                switch:
+                  - condition: ${deleteResp.code >= 400}
+                    raise:
+                      status_code: "error"
+                      message: ${"Failed to delete key " + key.name + "; HTTP " + string(deleteResp.code)}
+            - trackDelete:
+                assign:
+                  - deleted: ${list.concat(deleted, key.name)}
+
+    - done:
+        return:
+          status_code: "success"
+          message: ${"Deleted " + string(len(deleted)) + " user-managed key(s) on " + sa_name + ". Downstream consumers must re-authenticate; affected keys; " + json.encode_to_string(deleted)}

--- a/modules/response/templates/runbooks/StreamSecurityGcpRotateServiceAccountKeys.yaml
+++ b/modules/response/templates/runbooks/StreamSecurityGcpRotateServiceAccountKeys.yaml
@@ -53,8 +53,9 @@ main:
 
     - init:
         assign:
-          - keys: ${default(keysResp.body.keys, [])}
+          - keys: ${default(map.get(keysResp.body, "keys"), [])}
           - deleted: []
+          - already_revoked: 0
 
     - checkEmpty:
         switch:
@@ -78,9 +79,20 @@ main:
                   result: deleteResp
                 except:
                   as: er
-                  raise:
-                    status_code: "error"
-                    message: ${"Failed to delete key " + key.name + "; " + default(er.body.error.message, json.encode_to_string(er))}
+                  steps:
+                    - checkAlreadyGone:
+                        switch:
+                          - condition: ${er.code == 404}
+                            next: countSkip
+                    - rethrowDeleteError:
+                        raise:
+                          status_code: "error"
+                          message: ${"Failed to delete key " + key.name + "; " + default(er.body.error.message, json.encode_to_string(er))}
+                    - countSkip:
+                        assign:
+                          - already_revoked: ${already_revoked + 1}
+                    - nextKey:
+                        next: continue
             - checkDeleteStatus:
                 switch:
                   - condition: ${deleteResp.code >= 400}
@@ -92,6 +104,12 @@ main:
                   - deleted: ${list.concat(deleted, key.name)}
 
     - done:
-        return:
-          status_code: "success"
-          message: ${"Deleted " + string(len(deleted)) + " user-managed key(s) on " + sa_name + ". Downstream consumers must re-authenticate; affected keys; " + json.encode_to_string(deleted)}
+        switch:
+          - condition: ${len(deleted) == len(keys)}
+            return:
+              status_code: "success"
+              message: ${"Deleted " + string(len(deleted)) + " user-managed key(s) on " + sa_name + ". Affected keys; " + json.encode_to_string(deleted)}
+          - condition: true
+            return:
+              status_code: "partial_success"
+              message: ${"Deleted " + string(len(deleted)) + " of " + string(len(keys)) + " user-managed key(s) on " + sa_name + "; " + string(already_revoked) + " were already revoked before this run. Affected keys; " + json.encode_to_string(deleted)}

--- a/modules/response/templates/runbooks/StreamSecurityGcpRotateServiceAccountKeys.yaml
+++ b/modules/response/templates/runbooks/StreamSecurityGcpRotateServiceAccountKeys.yaml
@@ -16,7 +16,7 @@ main:
           - condition: ${text.match_regex(sa_input, "^projects/[^/]+/serviceAccounts/.+")}
             assign:
               - sa_name: ${sa_input}
-          - condition: ${text.match_regex(sa_input, ".+@.+")}
+          - condition: ${text.match_regex(sa_input, ".+@[^.]+[.]iam[.]gserviceaccount[.]com$")}
             assign:
               - parts: ${text.split(sa_input, "@")}
               - domain_parts: ${text.split(parts[1], ".")}
@@ -25,7 +25,7 @@ main:
           - condition: true
             raise:
               status_code: "error"
-              message: ${"Invalid ServiceAccountId. Expected 'projects/<p>/serviceAccounts/<email>' or a bare SA email ending in .iam.gserviceaccount.com; got; " + sa_input}
+              message: ${"Invalid ServiceAccountId. Expected 'projects/<p>/serviceAccounts/<email>' or a bare SA email ending in .iam.gserviceaccount.com; got: " + sa_input}
 
     # List only user-managed keys — system-managed keys are rotated by GCP
     # automatically and must not be deleted. The keyTypes filter does the

--- a/modules/response/templates/runbooks/StreamSecurityGcpRotateServiceAccountKeys.yaml
+++ b/modules/response/templates/runbooks/StreamSecurityGcpRotateServiceAccountKeys.yaml
@@ -16,7 +16,7 @@ main:
           - condition: ${text.match_regex(sa_input, "^projects/[^/]+/serviceAccounts/.+")}
             assign:
               - sa_name: ${sa_input}
-          - condition: ${text.find_all(sa_input, "@") != []}
+          - condition: ${text.match_regex(sa_input, ".+@.+")}
             assign:
               - parts: ${text.split(sa_input, "@")}
               - domain_parts: ${text.split(parts[1], ".")}
@@ -25,7 +25,7 @@ main:
           - condition: true
             raise:
               status_code: "error"
-              message: ${"Invalid ServiceAccountId. Expected 'projects/<p>/serviceAccounts/<email>' or a bare SA email; got; " + sa_input}
+              message: ${"Invalid ServiceAccountId. Expected 'projects/<p>/serviceAccounts/<email>' or a bare SA email ending in .iam.gserviceaccount.com; got; " + sa_input}
 
     # List only user-managed keys — system-managed keys are rotated by GCP
     # automatically and must not be deleted. The keyTypes filter does the
@@ -61,7 +61,7 @@ main:
           - condition: ${len(keys) == 0}
             return:
               status_code: "success"
-              message: ${"No user-managed keys on " + sa_name + "; nothing to rotate."}
+              message: ${"No user-managed keys on " + sa_name + "; nothing to revoke."}
 
     - deleteKeys:
         for:

--- a/modules/response/templates/runbooks/StreamSecurityGcpRotateServiceAccountKeys.yaml
+++ b/modules/response/templates/runbooks/StreamSecurityGcpRotateServiceAccountKeys.yaml
@@ -25,7 +25,7 @@ main:
           - condition: true
             raise:
               status_code: "error"
-              message: ${"Invalid ServiceAccountId. Expected 'projects/<p>/serviceAccounts/<email>' or a bare SA email ending in .iam.gserviceaccount.com; got: " + sa_input}
+              message: ${"Invalid ServiceAccountId. Expected 'projects/<p>/serviceAccounts/<email>' or a bare SA email ending in .iam.gserviceaccount.com; got; " + sa_input}
 
     # List only user-managed keys — system-managed keys are rotated by GCP
     # automatically and must not be deleted. The keyTypes filter does the

--- a/modules/response/templates/runbooks/StreamSecurityGcpRotateServiceAccountKeys.yaml
+++ b/modules/response/templates/runbooks/StreamSecurityGcpRotateServiceAccountKeys.yaml
@@ -62,7 +62,7 @@ main:
           - condition: ${len(keys) == 0}
             return:
               status_code: "success"
-              message: ${"No user-managed keys on " + sa_name + "; nothing to revoke."}
+              message: ${"No user-managed keys on " + sa_name + "; nothing to delete."}
 
     - deleteKeys:
         for:
@@ -112,4 +112,4 @@ main:
           - condition: true
             return:
               status_code: "partial_success"
-              message: ${"Deleted " + string(len(deleted)) + " of " + string(len(keys)) + " user-managed key(s) on " + sa_name + "; " + string(already_revoked) + " were already revoked before this run. Affected keys; " + json.encode_to_string(deleted)}
+              message: ${"Deleted " + string(len(deleted)) + " of " + string(len(keys)) + " user-managed key(s) on " + sa_name + "; " + string(already_revoked) + " were already deleted before this run. Affected keys; " + json.encode_to_string(deleted)}


### PR DESCRIPTION
## Summary
- Adds `StreamSecurityGcpRotateServiceAccountKeys` runbook entry to `runbook_config.yaml`
- Adds `StreamSecurityGcpRotateServiceAccountKeys.yaml` runbook — deletes all USER_MANAGED keys from a GCP service account (SYSTEM_MANAGED keys are skipped as they cannot be downloaded or deleted by users)
- Role file `gcp_revoke_service_account_keys.json` already present in this branch

Companion PR in lightlytics: https://github.com/lightlytics/lightlytics/pull/20625

## Test plan
- [ ] Trigger remediation on a service account with user-managed keys — verify all keys are deleted
- [ ] Trigger on a service account with no user-managed keys — verify `"nothing to revoke"` success message
- [ ] Pass a malformed `ServiceAccountId` — verify validation error fires with `.iam.gserviceaccount.com` hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)